### PR TITLE
Remove pytorch3d dependency

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,16 +1,10 @@
 ```
-conda create -n parahome python=3.9  
+conda create -n parahome python=3.9
 conda activate parahome
 
 # CUDA
 pip install torch==2.0.1 torchvision==0.15.2 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu118
 # without CUDA: check https://pytorch.org/get-started/previous-versions/ and install proper version
-
-# Install pytorch3D (It's just for debug visualization.)
-conda install -c fvcore -c iopath -c conda-forge fvcore iopath
-# CUDA
-pip install --no-index --no-cache-dir pytorch3d -f https://dl.fbaipublicfiles.com/pytorch3d/packaging/wheels/py39_cu118_pyt201/download.html  
-# without CUDA: check https://github.com/facebookresearch/pytorch3d/blob/main/INSTALL.md
 
 pip install open3d
 ```

--- a/visualize/rotation_conversions.py
+++ b/visualize/rotation_conversions.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn.functional as F
+
+
+def rotation_6d_to_matrix(d6: torch.Tensor) -> torch.Tensor:
+    """
+    Converts 6D rotation representation by Zhou et al. [1] to rotation matrix
+    using Gram--Schmidt orthogonalization per Section B of [1].
+    Args:
+        d6: 6D rotation representation, of size (*, 6)
+
+    Returns:
+        batch of rotation matrices of size (*, 3, 3)
+
+    [1] Zhou, Y., Barnes, C., Lu, J., Yang, J., & Li, H.
+    On the Continuity of Rotation Representations in Neural Networks.
+    IEEE Conference on Computer Vision and Pattern Recognition, 2019.
+    Retrieved from http://arxiv.org/abs/1812.07035
+    """
+
+    a1, a2 = d6[..., :3], d6[..., 3:]
+    b1 = F.normalize(a1, dim=-1)
+    b2 = a2 - (b1 * a2).sum(-1, keepdim=True) * b1
+    b2 = F.normalize(b2, dim=-1)
+    b3 = torch.cross(b1, b2, dim=-1)
+    return torch.stack((b1, b2, b3), dim=-2)

--- a/visualize/utils.py
+++ b/visualize/utils.py
@@ -1,11 +1,13 @@
 import torch
 import torch.nn as nn
-from pytorch3d.transforms import rotation_6d_to_matrix
 import json
 import os
 import open3d as o3d
 import numpy as np
 from matplotlib import pyplot as plt
+
+from rotation_conversions import rotation_6d_to_matrix
+
 
 body_order = {'pHipOrigin': 0,
  'jL5S1': 1,
@@ -436,4 +438,3 @@ def get_annotation(annotation, fn):
 
 from pathlib import Path
 annot2item = json.load(open(Path(__file__).parent.parent/'data'/'annot2item.json'))
-


### PR DESCRIPTION
It's a hassle to install pytorch3d, especially when we only use `rotation_6d_to_matrix` in the package.

This PR remove the dependency of pytorch3d. 